### PR TITLE
Adjust grafana-loki module to contain ingress

### DIFF
--- a/modules/grafana-loki/README.md
+++ b/modules/grafana-loki/README.md
@@ -16,3 +16,55 @@ module "grafana-loki" {
         memory = "128Mi"
     }
 }
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | ~>1.13.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | ~>1.13.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_grafana-loki"></a> [grafana-loki](#module\_grafana-loki) | terraform-module/release/helm | 2.7.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [kubectl_manifest.grafana-loki](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_path_documents.grafana-loki](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/path_documents) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_version"></a> [app\_version](#input\_app\_version) | App Chart Version | `string` | `"2.1.2"` | no |
+| <a name="input_cluster_issuer"></a> [cluster\_issuer](#input\_cluster\_issuer) | Cluster name ingress will be using to ask certificate from cert-manager for ingress | `string` | `""` | no |
+| <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Create Namespace | `bool` | `true` | no |
+| <a name="input_deploy"></a> [deploy](#input\_deploy) | Deploy | `number` | `1` | no |
+| <a name="input_enable_ingress"></a> [enable\_ingress](#input\_enable\_ingress) | n/a | `bool` | `true` | no |
+| <a name="input_force_update"></a> [force\_update](#input\_force\_update) | Force Update | `bool` | `true` | no |
+| <a name="input_grafana_enabled"></a> [grafana\_enabled](#input\_grafana\_enabled) | n/a | `bool` | `true` | no |
+| <a name="input_hostname"></a> [hostname](#input\_hostname) | The hostname grafana will be accessed by | `string` | n/a | yes |
+| <a name="input_ingress_annotations"></a> [ingress\_annotations](#input\_ingress\_annotations) | (optional) describe your variable | `list(any)` | `[]` | no |
+| <a name="input_name"></a> [name](#input\_name) | Application name | `string` | `"loki-stack"` | no |
+| <a name="input_prometheus_alertmanager_persistentVolume_enabled"></a> [prometheus\_alertmanager\_persistentVolume\_enabled](#input\_prometheus\_alertmanager\_persistentVolume\_enabled) | n/a | `bool` | `true` | no |
+| <a name="input_prometheus_enabled"></a> [prometheus\_enabled](#input\_prometheus\_enabled) | n/a | `bool` | `true` | no |
+| <a name="input_prometheus_server_persistentVolume_enabled"></a> [prometheus\_server\_persistentVolume\_enabled](#input\_prometheus\_server\_persistentVolume\_enabled) | n/a | `bool` | `true` | no |
+| <a name="input_recreate_pods"></a> [recreate\_pods](#input\_recreate\_pods) | Recreate pods | `bool` | `false` | no |
+| <a name="input_resources_limits"></a> [resources\_limits](#input\_resources\_limits) | The resources container | `any` | <pre>{<br>  "cpu": "500m",<br>  "memory": "256M"<br>}</pre> | no |
+| <a name="input_resources_requests"></a> [resources\_requests](#input\_resources\_requests) | The resources container | `any` | <pre>{<br>  "cpu": "250m",<br>  "memory": "256M"<br>}</pre> | no |
+| <a name="input_wait"></a> [wait](#input\_wait) | Wait | `bool` | `false` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/grafana-loki/grafana-loki-ingress.yaml
+++ b/modules/grafana-loki/grafana-loki-ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: loki
+  namespace: loki
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    cert-manager.io/cluster-issuer: ${cluster_issuer}
+spec:
+  tls:
+    - secretName: grafana-loki
+      hosts:
+      - ${hostname}
+  rules:
+  - host: ${hostname}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: loki-stack-grafana
+            port:
+              number: 80

--- a/modules/grafana-loki/ingress.tf
+++ b/modules/grafana-loki/ingress.tf
@@ -1,0 +1,17 @@
+data "kubectl_path_documents" "grafana-loki" {
+  pattern = "${path.module}/grafana-loki-ingress.yaml"
+
+  vars = {
+    cluster_issuer = var.cluster_issuer
+    hostname       = var.hostname
+  }
+}
+
+resource "kubectl_manifest" "grafana-loki" {
+  count     = var.enable_ingress ? 1 : 0
+  yaml_body = element(data.kubectl_path_documents.grafana-loki.documents, count.index)
+
+  depends_on = [
+    module.grafana-loki
+  ]
+}

--- a/modules/grafana-loki/main.tf
+++ b/modules/grafana-loki/main.tf
@@ -17,7 +17,12 @@ module "grafana-loki" {
   }
 
   values = [
-    templatefile("${path.module}/values.yaml", { resources_requests_cpu = "${var.resources_requests.cpu}", resources_requests_memory = "${var.resources_requests.memory}", resources_limits_cpu = "${var.resources_limits.cpu}", resources_limits_memory = "${var.resources_limits.memory}" })
+    templatefile("${path.module}/values.yaml", {
+      resources_requests_cpu    = "${var.resources_requests.cpu}",
+      resources_requests_memory = "${var.resources_requests.memory}",
+      resources_limits_cpu      = "${var.resources_limits.cpu}",
+      resources_limits_memory   = "${var.resources_limits.memory}"
+    })
   ]
 
   set = [

--- a/modules/grafana-loki/variables.tf
+++ b/modules/grafana-loki/variables.tf
@@ -40,14 +40,20 @@ variable "deploy" {
   description = "Deploy"
 }
 variable "resources_limits" {
-  type        = any
-  default     = {}
+  type = any
+  default = {
+    cpu    = "500m"
+    memory = "256M"
+  }
   description = "The resources container"
 }
 
 variable "resources_requests" {
-  type        = any
-  default     = {}
+  type = any
+  default = {
+    cpu    = "250m"
+    memory = "256M"
+  }
   description = "The resources container"
 }
 
@@ -69,4 +75,26 @@ variable "prometheus_alertmanager_persistentVolume_enabled" {
 variable "prometheus_server_persistentVolume_enabled" {
   type    = bool
   default = true
+}
+
+variable "enable_ingress" {
+  type    = bool
+  default = true
+}
+
+variable "cluster_issuer" {
+  type        = string
+  default     = ""
+  description = "Cluster name ingress will be using to ask certificate from cert-manager for ingress"
+}
+
+variable "hostname" {
+  type        = string
+  description = "The hostname grafana will be accessed by"
+}
+
+variable "ingress_annotations" {
+  type        = list(any)
+  default     = []
+  description = "(optional) describe your variable"
 }

--- a/modules/grafana-loki/versions.tf
+++ b/modules/grafana-loki/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~>1.13.0"
+    }
+  }
+}


### PR DESCRIPTION
Before ingress was separate terraform resource, adjusted to have this done in the same module (helm does seem to already take care of this, this might need to be revisited).